### PR TITLE
Bug: `Get-PSFavorites` errors out if a favorite doesn't have comment

### DIFF
--- a/Module/Public/Get-PSFavorites.ps1
+++ b/Module/Public/Get-PSFavorites.ps1
@@ -20,6 +20,12 @@ function Get-PSFavorites {
         # Convert the favorites to a PSCustomObject
         foreach ($Favorite in $Favorites) {
             $Command, $Description = $Favorite -split "\s*#\s*"
+
+            # If the favorite lacks a description, use the command itself as it's description
+            if ($null -eq $Description) {
+                $Description = $Command
+            }
+
             [PSCustomObject]@{
                 Command     = $Command.Trim()
                 Description = $Description.Trim()


### PR DESCRIPTION
Fixes #3