### PR TITLE
Fix issue with `Optimize-PSFavorites` wiping the entire `Favorites.txt` file

### DIFF
--- a/Module/Public/Optimize-PSFavorites.ps1
+++ b/Module/Public/Optimize-PSFavorites.ps1
@@ -3,14 +3,22 @@
     Optimize the favorites list
 .DESCRIPTION
     Optimize the favorites list. This will sort the list and remove duplicates.
-    The favorites list is stored in the `AppData\Local\PSFavorite\Favorites.txt` file.
+    The favorites list is stored in the Favorites.txt file in the PSFavorite module directory.
     The changes will be loaded in the next time the module is imported.
 .EXAMPLE
     Optimize-PSFavorites
     Sorts and removes duplicates from the favorites list.
 #>
 function Optimize-PSFavorites {
-    Get-Content -Path $Script:FavoritesPath
-    | Sort-Object -Unique
-    | Out-File -FilePath $Script:FavoritesPath
+    begin {
+        $Favorites = Get-Content -Path $Script:FavoritesPath
+    }
+
+    process {
+        $Favorites = $Favorites | Sort-Object -Unique
+    }
+
+    end {
+        $Favorites | Out-File -FilePath $Script:FavoritesPath
+    }
 }

--- a/Module/Public/Optimize-PSFavorites.ps1
+++ b/Module/Public/Optimize-PSFavorites.ps1
@@ -3,7 +3,7 @@
     Optimize the favorites list
 .DESCRIPTION
     Optimize the favorites list. This will sort the list and remove duplicates.
-    The favorites list is stored in the Favorites.txt file in the PSFavorite module directory.
+    The favorites list is stored in the `AppData\Local\PSFavorite\Favorites.txt` file in the PSFavorite module directory.
     The changes will be loaded in the next time the module is imported.
 .EXAMPLE
     Optimize-PSFavorites


### PR DESCRIPTION
This pull request reverts the commit that simplified the `Optimize-PSFavorites` logic due to flawed logic that wiped the entire file clean. The original logic is restored to ensure the correct functionality of sorting and removing duplicates from the favorites list.