### PR TITLE
Parameterize FavoritesPath in cmdlets

### DIFF
--- a/Module/Public/Add-PSFavorite.ps1
+++ b/Module/Public/Add-PSFavorite.ps1
@@ -18,7 +18,10 @@
 function Add-PSFavorite(
     # The command to add to the favorites list.
     [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
-    [string] $Command
+    [string] $Command,
+
+    # The path to the favorites list file.
+    [string] $FavoritesPath = $Script:FavoritesPath
 ) {
-    $Command | Out-File -FilePath $Script:FavoritesPath -Append
+    $Command | Out-File -FilePath $FavoritesPath -Append
 }

--- a/Module/Public/Get-PSFavorites.ps1
+++ b/Module/Public/Get-PSFavorites.ps1
@@ -11,9 +11,12 @@
     Get-PSFavorites | Out-GridView
     Get the list of commands in the favorites list and display it in a GridView.
 #>
-function Get-PSFavorites {
+function Get-PSFavorites(
+    # The path to the favorites list file.
+    [string] $FavoritesPath = $Script:FavoritesPath
+) {
     # Get the favorites from the file
-    $Favorites = Get-Content -Path $Script:FavoritesPath
+    $Favorites = Get-Content -Path $FavoritesPath
 
     # Convert the favorites to a PSCustomObject
     foreach ($Favorite in $Favorites) {

--- a/Module/Public/Optimize-PSFavorites.ps1
+++ b/Module/Public/Optimize-PSFavorites.ps1
@@ -9,9 +9,12 @@
     Optimize-PSFavorites
     Sorts and removes duplicates from the favorites list.
 #>
-function Optimize-PSFavorites {
+function Optimize-PSFavorites(
+    # The path to the favorites list file.
+    [string] $FavoritesPath = $Script:FavoritesPath
+) {
     begin {
-        $Favorites = Get-Content -Path $Script:FavoritesPath
+        $Favorites = Get-Content -Path $FavoritesPath
     }
 
     process {
@@ -19,6 +22,6 @@ function Optimize-PSFavorites {
     }
 
     end {
-        $Favorites | Out-File -FilePath $Script:FavoritesPath
+        $Favorites | Out-File -FilePath $FavoritesPath
     }
 }

--- a/Module/Public/Remove-PSFavorite.ps1
+++ b/Module/Public/Remove-PSFavorite.ps1
@@ -22,11 +22,14 @@ function Remove-PSFavorite {
         # The command(s) to remove from the favorites list
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [PSObject[]] $Command
+        [PSObject[]] $Command,
+
+        # The path to the favorites list file
+        [string] $FavoritesPath = $Script:FavoritesPath
     )
 
     # Read the Favorites.txt content
-    $Favorites = Get-Content -Path $Script:FavoritesPath
+    $Favorites = Get-Content -Path $FavoritesPath
 
     foreach ($Cmd in $Command) {
         # Extract the command name from the PSObject or use the provided string
@@ -44,7 +47,7 @@ function Remove-PSFavorite {
 
     # Write the filtered Favorites out to the Favorites.txt file
     if ($PSCmdlet.ShouldProcess("Save changes to the favorites list?")) {
-        $Favorites | Out-File -FilePath $Script:FavoritesPath
+        $Favorites | Out-File -FilePath $FavoritesPath
         Write-Verbose "Changes saved to the favorites list."
     }
 


### PR DESCRIPTION
This pull request parameterizes the `FavoritesPath` variable in the cmdlets. It adds a new parameter `FavoritesPath` to the `Add-PSFavorite`, `Get-PSFavorites`, `Optimize-PSFavorites`, and `Remove-PSFavorite` functions. This allows users to specify a custom path for the favorites list file instead of using the default path (`$Script:FavoritesPath`).