### PR TITLE
Fix predictor path synchronization and enhance thread safety

### DIFF
--- a/Module/PSFavorite.psd1
+++ b/Module/PSFavorite.psd1
@@ -76,7 +76,8 @@
         "Get-PSFavorites",
         "Initialize-PSFavorite",
         "Optimize-PSFavorites",
-        "Remove-PSFavorite"
+        "Remove-PSFavorite",
+        "Unregister-PSFavoritePredictor"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Module/PSFavorite.psm1
+++ b/Module/PSFavorite.psm1
@@ -18,3 +18,8 @@ Get-ChildItem -Path "$PSScriptRoot\Public" -Filter "*.ps1" | ForEach-Object {
 
 # Initialize the PSFavorite module with the default configuration
 Initialize-PSFavorite
+
+# Load the favorites from the configuration file if it exists
+if ($Script:FavoritesPath) {
+    [PSFavorite.PSFavoritePredictor]::Initialize($Script:FavoritesPath)
+}

--- a/Module/Private/Initialize-Configuration.ps1
+++ b/Module/Private/Initialize-Configuration.ps1
@@ -19,6 +19,9 @@ function Initialize-Configuration(
     # Name of the parent folder
     [string] $ModuleName = "PSFavorite",
 
+    # Name of the configuration file
+    [string] $FavoritesFile = "Favorites.txt",
+
     # Path to the configuration file
     [string] $FavoritesPath
 ) {
@@ -31,9 +34,7 @@ function Initialize-Configuration(
     else {
         # Create the PSFavorite directory if it doesn't already exist
         $local = if ($IsWindows) { $Env:LOCALAPPDATA } else { "$HOME/.local/share" }
-        $folder = Join-Path $local $ModuleName    
-        # Path to the Favorites file
-        $Script:FavoritesPath = Join-Path $folder "Favorites.txt"    
+        $Script:FavoritesPath = Join-Path $local $ModuleName $FavoritesFile    
     }
 
     # Create the directory if it doesn't exist

--- a/Module/Public/Unregister-PSFavoritePredictor.ps1
+++ b/Module/Public/Unregister-PSFavoritePredictor.ps1
@@ -1,0 +1,14 @@
+<#
+.SYNOPSIS
+    Unregister the PSFavorite predictor from PSReadLine.
+.DESCRIPTION
+    Explicitly removes the PSFavorite predictor from the PSReadLine subsystem.
+    This is safe to call multiple times and is useful for testing or when you
+    want to cleanly unload the predictor before re-importing the module.
+.EXAMPLE
+    Unregister-PSFavoritePredictor
+    Unregisters the predictor from PSReadLine.
+#>
+function Unregister-PSFavoritePredictor {
+    [PSFavorite.PSFavoritePredictor]::Unregister()
+}

--- a/Module/Tests/Public/PredictorInitialization.Tests.ps1
+++ b/Module/Tests/Public/PredictorInitialization.Tests.ps1
@@ -1,0 +1,27 @@
+Describe "Predictor initialization on first import" {
+    Context "When initializing module with a custom favorites path" {
+        It "Creates the favorites file when given a temp path" {
+            $testRoot = Join-Path $PSScriptRoot '..\temp-' + ([guid]::NewGuid().ToString())
+            New-Item -Path $testRoot -ItemType Directory -Force | Out-Null
+
+            $favoritesFile = Join-Path $testRoot 'PSFavorite\Favorites.txt'
+
+            try {
+                # Import the module (should not throw)
+                $manifest = Join-Path (Join-Path $PSScriptRoot '..\..') 'PSFavorite.psd1'
+                Import-Module $manifest -Force -ErrorAction Stop
+
+                # Initialize using a custom favorites path under our temp folder
+                Initialize-PSFavorite -FavoritesPath $favoritesFile -ErrorAction Stop
+
+                # Assert the favorites file exists
+                Test-Path $favoritesFile | Should -BeTrue
+            }
+            finally {
+                # Cleanup: remove module and temp folder
+                Remove-Module PSFavorite -ErrorAction SilentlyContinue
+                Remove-Item -Path $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/Module/Tests/Public/PredictorInitialization.Tests.ps1
+++ b/Module/Tests/Public/PredictorInitialization.Tests.ps1
@@ -18,7 +18,8 @@ Describe "Predictor initialization on first import" {
                 Test-Path $favoritesFile | Should -BeTrue
             }
             finally {
-                # Cleanup: remove module and temp folder
+                # Cleanup: unregister predictor, remove module and temp folder
+                Unregister-PSFavoritePredictor -ErrorAction SilentlyContinue
                 Remove-Module PSFavorite -ErrorAction SilentlyContinue
                 Remove-Item -Path $testRoot -Recurse -Force -ErrorAction SilentlyContinue
             }

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -124,9 +124,20 @@ namespace PSFavorite
             {
                 return default;
             }
+            
+            string[] favoritesSnapshot;
+            lock (_favoritesLock)
+            {
+                favoritesSnapshot = _favorites;
+            }
 
-            List<PredictiveSuggestion> suggestions = _favorites
-                .Select(line => (Line: line!, Score: DetermineScore(input, line!)))             // Determine the score for each line.
+            if (favoritesSnapshot is null || favoritesSnapshot.Length == 0)
+            {
+                return default;
+            }
+
+            List<PredictiveSuggestion> suggestions = favoritesSnapshot
+                .Select(line => (Line: line, Score: DetermineScore(input, line)))               // Determine the score for each line.
                 .Where(tuple => tuple.Score >= ScoreThreshold)                                  // Filter out the lines below the score threshold.
                 .OrderByDescending(tuple => tuple.Score)                                        // Order the list by the score in descending order.
                 .Select(tuple => new PredictiveSuggestion(tuple.Line, GetTooltip(tuple.Line)))  // Create a PredictiveSuggestion object for selected line.

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -80,10 +80,9 @@ namespace PSFavorite
                 // Check if the favorites file exists. If it does, read all lines and update the _favorites array.
                 if (File.Exists(_FavoritesFilePath))
                 {
-                    var lines = File.ReadAllLines(_FavoritesFilePath);
                     lock (_favoritesLock)
                     {
-                        _favorites = lines;
+                        _favorites = File.ReadAllLines(_FavoritesFilePath);
                     }
                 }
                 // ...otherwise, if the file does not exist, set _favorites to an empty array.

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -33,6 +33,9 @@ namespace PSFavorite
         /// </summary>
         public string Description => "A predictor that uses a list of favorite commands to provide suggestions.";
 
+        /// A fixed GUID to identify the predictor. This should be unique to avoid conflicts with other predictors.
+        internal const string Identifier = "843b51d0-55c8-4c1a-8116-f0728d419306";
+
         #region "Favorites"
 
         /// <summary>
@@ -261,6 +264,22 @@ namespace PSFavorite
         public void OnCommandLineExecuted(PredictionClient client, string commandLine, bool success) { }
 
         #endregion
+
+        /// <summary>
+        /// Explicitly unregister the predictor from the PSReadLine subsystem.
+        /// Safe to call multiple times; silently ignores if not currently registered.
+        /// </summary>
+        public static void Unregister()
+        {
+            try
+            {
+                SubsystemManager.UnregisterSubsystem(SubsystemKind.CommandPredictor, new Guid(Identifier));
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not registered"))
+            {
+                // Predictor was already unregistered or never registered; no-op.
+            }
+        }
     }
 
     /// <summary>
@@ -268,26 +287,20 @@ namespace PSFavorite
     /// </summary>
     public class Init : IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
-        private const string Identifier = "843b51d0-55c8-4c1a-8116-f0728d419306";
-
         /// <summary>
         /// Gets called when assembly is loaded.
         /// </summary>
         public void OnImport()
         {
-            var predictor = new PSFavoritePredictor(Identifier);
+            var predictor = new PSFavoritePredictor(PSFavoritePredictor.Identifier);
             try
             {
                 SubsystemManager.RegisterSubsystem(SubsystemKind.CommandPredictor, predictor);
             }
-            catch (InvalidOperationException ex)
+            catch (InvalidOperationException ex) when (ex.Message.Contains("already registered"))
             {
                 // The predictor may already be registered (e.g., repeated module import in the same process).
                 // Treat duplicate registration as a no-op to make initialization idempotent.
-                if (!ex.Message.Contains("already registered"))
-                {
-                    throw;
-                }
             }
         }
 
@@ -296,7 +309,7 @@ namespace PSFavorite
         /// </summary>
         public void OnRemove(PSModuleInfo psModuleInfo)
         {
-            SubsystemManager.UnregisterSubsystem(SubsystemKind.CommandPredictor, new Guid(Identifier));
+            PSFavoritePredictor.Unregister();
         }
     }
 }

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -275,7 +275,7 @@ namespace PSFavorite
             {
                 SubsystemManager.UnregisterSubsystem(SubsystemKind.CommandPredictor, new Guid(Identifier));
             }
-            catch (InvalidOperationException ex) when (ex.Message.Contains("not registered"))
+            catch (InvalidOperationException)
             {
                 // Predictor was already unregistered or never registered; no-op.
             }

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -276,7 +276,19 @@ namespace PSFavorite
         public void OnImport()
         {
             var predictor = new PSFavoritePredictor(Identifier);
-            SubsystemManager.RegisterSubsystem(SubsystemKind.CommandPredictor, predictor);
+            try
+            {
+                SubsystemManager.RegisterSubsystem(SubsystemKind.CommandPredictor, predictor);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // The predictor may already be registered (e.g., repeated module import in the same process).
+                // Treat duplicate registration as a no-op to make initialization idempotent.
+                if (!ex.Message.Contains("already registered"))
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -1,4 +1,9 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Collections.Generic;
+using System.Management.Automation;
 using System.Management.Automation.Subsystem;
 using System.Management.Automation.Subsystem.Prediction;
 
@@ -28,15 +33,82 @@ namespace PSFavorite
         /// </summary>
         public string Description => "A predictor that uses a list of favorite commands to provide suggestions.";
 
-        /// <summary>
-        /// The file path of the favorite commands file.
-        /// </summary>
-        private static readonly string _FavoritesFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PSFavorite", "Favorites.txt");
+        #region "Favorites"
 
         /// <summary>
-        /// A list of favorite commands.
+        /// The file path of the favorite commands file.
+        /// For Windows, the default path is "%LocalAppData%\PSFavorite\Favorites.txt" and for Linux/macOS, the default path is "$HOME/.local/share/PSFavorite/Favorites.txt".
+        /// The file is expected to contain one favorite command per line, and an optional description after a '#' character.
         /// </summary>
-        private readonly string[] favorites = File.ReadAllLines(_FavoritesFilePath);
+        private static string _FavoritesFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PSFavorite", "Favorites.txt");
+
+        /// <summary>
+        /// A cached list of favorite commands.
+        /// Can be updated by calling LoadFavoritesIfExists, which is triggered during initialization.
+        /// </summary>
+        private static string[] _favorites = Array.Empty<string>();
+
+        /// <summary>
+        /// An object used for locking access to the favorites array to ensure thread safety.
+        /// This is necessary because the predictor may be called from multiple threads concurrently, and we want to avoid race conditions
+        /// when loading or accessing the favorites.
+        /// </summary>
+        private static readonly object _favoritesLock = new object();
+
+        /// <summary>
+        /// Initialize the predictor with an explicit favorites path.
+        /// Safe to call from PowerShell after the module's configuration is resolved.
+        /// </summary>
+        /// <param name="favoritesPath">Full path to the favorites file.</param>
+        public static void Initialize(string favoritesPath)
+        {
+            if (!string.IsNullOrWhiteSpace(favoritesPath))
+            {
+                _FavoritesFilePath = favoritesPath;
+            }
+
+            LoadFavoritesIfExists();
+        }
+
+        /// <summary>
+        /// Load the favorites from the file if it exists. If any error occurs, set favorites to an empty array.
+        /// </summary>
+        private static void LoadFavoritesIfExists()
+        {
+            try
+            {
+                // Check if the favorites file exists. If it does, read all lines and update the _favorites array.
+                if (File.Exists(_FavoritesFilePath))
+                {
+                    var lines = File.ReadAllLines(_FavoritesFilePath);
+                    lock (_favoritesLock)
+                    {
+                        _favorites = lines;
+                    }
+                }
+                // ...otherwise, if the file does not exist, set _favorites to an empty array.
+                else
+                {
+                    lock (_favoritesLock)
+                    {
+                        _favorites = Array.Empty<string>();
+                    }
+                }
+            }
+            // If any exception occurs during file access (e.g., file is locked, permission issues, etc.),
+            // catch the exception and set _favorites to an empty array to avoid crashing the predictor.
+            catch
+            {
+                lock (_favoritesLock)
+                {
+                    _favorites = Array.Empty<string>();
+                }
+            }
+        }
+
+        #endregion
+
+        #region "Suggestions"
 
         /// <summary>
         /// Get the predictive suggestions. It indicates the start of a suggestion rendering session.
@@ -54,9 +126,8 @@ namespace PSFavorite
                 return default;
             }
 
-            // Generate the list of predictive suggestions.
-            List<PredictiveSuggestion> suggestions = favorites
-                .Select(line => (Line: line, Score: DetermineScore(input, line)))               // Determine the score for each line.
+            List<PredictiveSuggestion> suggestions = _favorites
+                .Select(line => (Line: line!, Score: DetermineScore(input, line!)))             // Determine the score for each line.
                 .Where(tuple => tuple.Score >= ScoreThreshold)                                  // Filter out the lines below the score threshold.
                 .OrderByDescending(tuple => tuple.Score)                                        // Order the list by the score in descending order.
                 .Select(tuple => new PredictiveSuggestion(tuple.Line, GetTooltip(tuple.Line)))  // Create a PredictiveSuggestion object for selected line.
@@ -130,6 +201,8 @@ namespace PSFavorite
             }
         }
 
+        #endregion
+
         #region "interface methods for processing feedback"
 
         /// <summary>
@@ -177,7 +250,7 @@ namespace PSFavorite
         /// <param name="success">Shows whether the execution was successful.</param>
         public void OnCommandLineExecuted(PredictionClient client, string commandLine, bool success) { }
 
-        #endregion;
+        #endregion
     }
 
     /// <summary>

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -11,8 +11,16 @@ namespace PSFavorite
 {
     public class PSFavoritePredictor : ICommandPredictor
     {
+        /// <summary>
+        /// The unique identifier for this predictor instance.
+        /// This is set through the constructor and used for registration with the subsystem manager.
+        /// </summary>
         private readonly Guid _guid;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSFavoritePredictor"/> class with a specified GUID.
+        /// </summary>
+        /// <param name="guid">The GUID to associate with this predictor instance.</param>
         internal PSFavoritePredictor(string guid)
         {
             _guid = new Guid(guid);
@@ -33,7 +41,10 @@ namespace PSFavorite
         /// </summary>
         public string Description => "A predictor that uses a list of favorite commands to provide suggestions.";
 
+        /// <summary>
         /// A fixed GUID to identify the predictor. This should be unique to avoid conflicts with other predictors.
+        /// This is used for registration and unregistration of the predictor with the subsystem manager.
+        /// </summary>
         internal const string Identifier = "843b51d0-55c8-4c1a-8116-f0728d419306";
 
         #region "Favorites"


### PR DESCRIPTION
This pull request introduces improvements to the PSFavorite module's configuration and initialization, especially around the handling and loading of the favorites file, and adds a new test for predictor initialization. The main changes enhance flexibility in specifying the favorites file path, ensure thread safety when accessing favorites, and improve robustness in file handling.

**Configuration and Initialization Improvements:**

* Added a `FavoritesFile` parameter to `Initialize-Configuration`, allowing customization of the favorites file name (`Module/Private/Initialize-Configuration.ps1`).
* Changed the logic for constructing the favorites file path to use the customizable file name and ensured the path is set in `$Script:FavoritesPath` (`Module/Private/Initialize-Configuration.ps1`).
* On module import, the predictor is now explicitly initialized with the resolved favorites path, ensuring it loads favorites from the correct location (`Module/PSFavorite.psm1`).

**Predictor Implementation Enhancements:**

* Refactored `PSFavoritePredictor` to allow dynamic initialization of the favorites file path, added thread safety for accessing the favorites list, and improved error handling when loading favorites (`Predictor/PSFavoritePredictor.cs`). [[1]](diffhunk://#diff-e6f5471c5c73ff24c83e80cdbcc3ca968fbd56bc6d47fef6da5b76004f2b7188R36-R110) [[2]](diffhunk://#diff-e6f5471c5c73ff24c83e80cdbcc3ca968fbd56bc6d47fef6da5b76004f2b7188L57-R139) [[3]](diffhunk://#diff-e6f5471c5c73ff24c83e80cdbcc3ca968fbd56bc6d47fef6da5b76004f2b7188R214-R215) [[4]](diffhunk://#diff-e6f5471c5c73ff24c83e80cdbcc3ca968fbd56bc6d47fef6da5b76004f2b7188L180-R263)

**Testing:**

* Added a test to verify that initializing the module with a custom favorites path creates the favorites file as expected (`Module/Tests/Public/PredictorInitialization.Tests.ps1`).

Fixes #14