### PR TITLE
Add reload functionality to update favorites in predictor after modifications

### DIFF
--- a/Module/Public/Add-PSFavorite.ps1
+++ b/Module/Public/Add-PSFavorite.ps1
@@ -24,4 +24,5 @@ function Add-PSFavorite(
     [string] $FavoritesPath = $Script:FavoritesPath
 ) {
     $Command | Out-File -FilePath $FavoritesPath -Append
+    [PSFavorite.PSFavoritePredictor]::Reload()
 }

--- a/Module/Public/Optimize-PSFavorites.ps1
+++ b/Module/Public/Optimize-PSFavorites.ps1
@@ -23,5 +23,6 @@ function Optimize-PSFavorites(
 
     end {
         $Favorites | Out-File -FilePath $FavoritesPath
+        [PSFavorite.PSFavoritePredictor]::Reload()
     }
 }

--- a/Module/Public/Remove-PSFavorite.ps1
+++ b/Module/Public/Remove-PSFavorite.ps1
@@ -49,6 +49,7 @@ function Remove-PSFavorite {
     if ($PSCmdlet.ShouldProcess("Save changes to the favorites list?")) {
         $Favorites | Out-File -FilePath $FavoritesPath
         Write-Verbose "Changes saved to the favorites list."
+        [PSFavorite.PSFavoritePredictor]::Reload()
     }
 
 }

--- a/Predictor/PSFavoritePredictor.cs
+++ b/Predictor/PSFavoritePredictor.cs
@@ -85,6 +85,15 @@ namespace PSFavorite
         }
 
         /// <summary>
+        /// Reload the favorites from the file. Call this after modifying the favorites file
+        /// to immediately reflect changes in the predictor.
+        /// </summary>
+        public static void Reload()
+        {
+            LoadFavoritesIfExists();
+        }
+
+        /// <summary>
         /// Load the favorites from the file if it exists. If any error occurs, set favorites to an empty array.
         /// </summary>
         private static void LoadFavoritesIfExists()


### PR DESCRIPTION
Implement a reload method to refresh the favorites in the predictor immediately after modifications are made to the favorites file. This ensures that changes are reflected without requiring a restart or manual refresh.

Fixes #16